### PR TITLE
Fixed json to 'json' for datatype field and added *.json file extensions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - feature/*
+      - hotfix/*
   pull_request:
 
 jobs:

--- a/src/options_market_maker/market_data/alpha_vantage.py
+++ b/src/options_market_maker/market_data/alpha_vantage.py
@@ -25,7 +25,7 @@ def get_historical_options(symbol, date):
     symbol_path = RAW_DATA_DIR / f'options/{symbol}'
     symbol_path.mkdir(parents=True, exist_ok=True)
 
-    filename = symbol_path / f'{symbol}_{date}'
+    filename = symbol_path / f'{symbol}_{date}.json'
     
     if filename.exists():
         print(f'Loading cached data from {filename}')
@@ -67,7 +67,7 @@ def get_daily_time_series_stocks(symbol, outputsize='full'):
     path = RAW_DATA_DIR / f'stocks/'
     path.mkdir(parents=True, exist_ok=True)
 
-    filename = path / f'{symbol}'
+    filename = path / f'{symbol}.json'
 
     if filename.exists():
         print(f'Loading cached data from {filename}')
@@ -83,7 +83,7 @@ def get_daily_time_series_stocks(symbol, outputsize='full'):
         'function': 'TIME_SERIES_DAILY',
         'symbol': symbol,
         'outputsize': outputsize,
-        'datatype': json,
+        'datatype': 'json',
         'apikey': ALPHA_VANTAGE_API_KEY
     }
 


### PR DESCRIPTION
- In the daily time series retrieval function we had put the datatype field to json instead of the string 'json', this was fixed
- Also added to the datafile that we save the extension .json to avoid confusion
- Additionally added to CI the hotfix branches