### PR TITLE
Added more unit tests against real historical market data

### DIFF
--- a/tests/test_implied_volatility.py
+++ b/tests/test_implied_volatility.py
@@ -1,6 +1,9 @@
+import json
+from pathlib import Path
 from options_market_maker.pricing.implied_volatility import implied_volatility
 
 
+# theoretical tests
 def test_implied_volatility_call():
     iv = implied_volatility(price_market=10.45,
                             S=100,
@@ -27,3 +30,37 @@ def test_implied_volatility_no_solution():
                             r=0.05,
                             option_type="call")
     assert iv != iv  # Expect NaN when no solution exists (NaN != NaN)
+
+
+# tests against real historical market data
+ROOT_DIR = Path.cwd()
+symbol = 'AAPL'
+date = '2023-09-19'
+samples_path = ROOT_DIR / f'data/samples/options/{symbol}/{symbol}_{date}.json'
+samples = json.loads(samples_path.read_text())
+
+def test_real_implied_volatility_call():
+    n = samples['ncalls'] // 2
+    option = samples['calls'][n]
+    price = (option['bid'] + option['ask']) / 2
+    S = samples['symbol_close']
+    K = option['strike']
+    T = option['time-to-expiry']
+    r = 0.055   # risk-free rate is hard-coded from internet
+    sigma = option['implied_volatility']
+    predicted_sigma = implied_volatility(price, S, K, T, r, 'call')
+
+    assert abs(sigma - predicted_sigma) / sigma < 0.05
+
+def test_real_implied_volatility_put():
+    n = samples['nputs'] // 2
+    option = samples['puts'][n]
+    price = (option['bid'] + option['ask']) / 2
+    S = samples['symbol_close']
+    K = option['strike']
+    T = option['time-to-expiry']
+    r = 0.055   # risk-free rate is hard-coded from internet
+    sigma = option['implied_volatility']
+    predicted_sigma = implied_volatility(price, S, K, T, r, 'put')
+
+    assert abs(sigma - predicted_sigma) / sigma < 0.05


### PR DESCRIPTION
- Using our historical sample data for AAPL, I introduced new unit tests for Black Scholes option pricing, implied volatility and calculation of Greeks
- All results are compared to the historical market data and checked for having less than a 5% discrepancy from the real data
- If tests pass, our predictions are thus within a 5% range around the real market data